### PR TITLE
Funcionalidade de retorno no Kanban

### DIFF
--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -2,14 +2,14 @@ import { useState } from 'react'
 import deleteIcon from '../assets/delete_outline.svg'
 
 interface Props {
-    id: number
     title: string
     description: string
     onDelete: () => void
-    onMove: () => void
+    onMove?: () => void
+    onMoveBack?: () => void
 }
 
-export function KanbanCard({id, title, description, onDelete, onMove}: Props) {
+export function KanbanCard({ title, description, onDelete, onMove, onMoveBack }: Props) {
     const [expanded, setExpanded] = useState(false) 
     const [showMenu, setShowMenu] = useState(false)
 
@@ -35,11 +35,23 @@ export function KanbanCard({id, title, description, onDelete, onMove}: Props) {
                     
                 </button>
 
-                <button 
-                    onClick={onMove}
-                    className="bg-primary-dark rounded-full w-8 h-8 flex items-center justify-center hover:bg-primary-dark/80 transition-colors cursor-pointer">
-                    <span className="material-icons text-white text-sm">chevron_right</span>
-                </button>
+                <div className="flex items-center gap-2">
+                    {onMoveBack && (
+                        <button 
+                            onClick={onMoveBack}
+                            className="bg-primary-dark rounded-full w-8 h-8 flex items-center justify-center hover:bg-primary-dark/80 transition-colors cursor-pointer">
+                            <span className="material-icons text-white text-sm">chevron_left</span>
+                        </button>
+                    )}
+
+                    {onMove && (
+                        <button 
+                            onClick={onMove}
+                            className="bg-primary-dark rounded-full w-8 h-8 flex items-center justify-center hover:bg-primary-dark/80 transition-colors cursor-pointer">
+                            <span className="material-icons text-white text-sm">chevron_right</span>
+                        </button>
+                    )}
+                </div>
 
             </div> 
 

--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -7,9 +7,11 @@ interface Props {
     onDelete: () => void
     onMove?: () => void
     onMoveBack?: () => void
+    onReturn?: () => void
+    isDone?: boolean
 }
 
-export function KanbanCard({ title, description, onDelete, onMove, onMoveBack }: Props) {
+export function KanbanCard({ title, description, onDelete, onMove, onMoveBack, onReturn, isDone }: Props) {
     const [expanded, setExpanded] = useState(false) 
     const [showMenu, setShowMenu] = useState(false)
 
@@ -17,7 +19,7 @@ export function KanbanCard({ title, description, onDelete, onMove, onMoveBack }:
         <div className="bg-white rounded-xl p-4 shadow-sm relative">
             
             <div className="flex items-center justify-between mb-2">
-                <h3 className="font-bold text-base">{title}</h3>
+                <h3 className={`font-bold text-base ${isDone ? 'line-through text-black' : ''}`}>{title}</h3>
                 <button onClick={() => setShowMenu(!showMenu)}>
                     <span className={`material-icons ${showMenu ? 'text-primary-dark' : 'text-gray-500'}`}>more_vert</span>
                 </button>
@@ -39,8 +41,16 @@ export function KanbanCard({ title, description, onDelete, onMove, onMoveBack }:
                     {onMoveBack && (
                         <button 
                             onClick={onMoveBack}
+                            className="bg-transparent border border-gray-200 rounded-full w-8 h-8 flex items-center justify-center hover:bg-gray-100 transition-colors cursor-pointer">
+                            <span className="material-icons text-primary-dark text-sm">chevron_left</span>
+                        </button>
+                    )}
+
+                    {onReturn && (
+                        <button 
+                            onClick={onReturn}
                             className="bg-primary-dark rounded-full w-8 h-8 flex items-center justify-center hover:bg-primary-dark/80 transition-colors cursor-pointer">
-                            <span className="material-icons text-white text-sm">chevron_left</span>
+                            <span className="material-icons text-white text-sm">rotate_left</span>
                         </button>
                     )}
 

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -18,7 +18,7 @@ export function KanbanColumn({title, showAdd, cards, onMoveCard, onMoveBack, onR
     const [showModal, setShowModal] = useState(false)
 
     return (
-        <div className="flex flex-col flex-1">
+        <div className="flex flex-col flex-1 min-h-0">
             
             <div className="flex items-center justify-between mb-3 px-1">
                 <h2 className="text-2xl font-poppins">{title}</h2>
@@ -29,7 +29,7 @@ export function KanbanColumn({title, showAdd, cards, onMoveCard, onMoveBack, onR
                 )}
             </div>
 
-            <div className="flex flex-col flex-1 bg-[#EEEEEE] p-4 rounded-xl shadow-sm gap-4"> 
+            <div className="flex flex-col flex-1 min-h-0 overflow-y-auto bg-[#EEEEEE] p-4 rounded-xl shadow-sm gap-4"> 
                 {cards.map(card => ( 
                     <KanbanCard
                         key={card.id}

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -9,10 +9,11 @@ interface Props {
     showAdd?: boolean
     cards: Card[]
     onMoveCard: (cardId: number) => void
+    onMoveBack?: (cardId: number) => void
     onDeleteCard: (cardId: number) => void
 }
 
-export function KanbanColumn({title, showAdd, cards, onMoveCard, onDeleteCard}: Props) {
+export function KanbanColumn({title, showAdd, cards, onMoveCard, onMoveBack, onDeleteCard}: Props) {
     const [showModal, setShowModal] = useState(false)
 
     return (
@@ -31,11 +32,11 @@ export function KanbanColumn({title, showAdd, cards, onMoveCard, onDeleteCard}: 
                 {cards.map(card => ( 
                     <KanbanCard
                         key={card.id}
-                        id={card.id} 
                         title={card.title} 
                         description={card.description} 
                         onDelete={() => onDeleteCard(card.id)}
                         onMove={() => onMoveCard(card.id)}
+                        onMoveBack={onMoveBack ? () => onMoveBack(card.id) : undefined}
                     />
                 ))} 
             </div>

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -8,12 +8,13 @@ interface Props {
     title: string
     showAdd?: boolean
     cards: Card[]
-    onMoveCard: (cardId: number) => void
+    onMoveCard?: (cardId: number) => void
     onMoveBack?: (cardId: number) => void
+    onReturn?: (cardId: number) => void
     onDeleteCard: (cardId: number) => void
 }
 
-export function KanbanColumn({title, showAdd, cards, onMoveCard, onMoveBack, onDeleteCard}: Props) {
+export function KanbanColumn({title, showAdd, cards, onMoveCard, onMoveBack, onReturn, onDeleteCard}: Props) {
     const [showModal, setShowModal] = useState(false)
 
     return (
@@ -35,8 +36,10 @@ export function KanbanColumn({title, showAdd, cards, onMoveCard, onMoveBack, onD
                         title={card.title} 
                         description={card.description} 
                         onDelete={() => onDeleteCard(card.id)}
-                        onMove={() => onMoveCard(card.id)}
+                        onMove={onMoveCard ? () => onMoveCard(card.id) : undefined}
                         onMoveBack={onMoveBack ? () => onMoveBack(card.id) : undefined}
+                        onReturn={onReturn ? () => onReturn(card.id) : undefined}
+                        isDone={card.column === 'done'}
                     />
                 ))} 
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,4 +22,5 @@
 
 body {
   font-family: 'Poppins', sans-serif;
-} 
+}
+ 

--- a/frontend/src/pages/Kanban.tsx
+++ b/frontend/src/pages/Kanban.tsx
@@ -36,7 +36,8 @@ export function Kanban() {
             setCards(cards.map(c => 
                 c.id === cardId ? { ...c, column: nextColumn } : c
             ))
-        } catch (error) {
+        } 
+        catch (error) {
             console.error('erro mover card:', error)
         }
     } 
@@ -68,7 +69,8 @@ export function Kanban() {
             setCards(cards.map(c => 
                 c.id === cardId ? { ...c, column: 'todo' } : c
             ))
-        } catch (error) {
+        } 
+        catch (error) {
             console.error('erro retornar card para a fazer:', error)
         }
     }
@@ -88,7 +90,7 @@ export function Kanban() {
             <KanbanHeader />
             <QuoteCard />
 
-            <div className="flex flex-1 gap-15 px-40 py-10">
+            <div className="flex flex-1 min-h-0 gap-15 px-40 py-10">
                 <KanbanColumn
                     title="A fazer"
                     showAdd

--- a/frontend/src/pages/Kanban.tsx
+++ b/frontend/src/pages/Kanban.tsx
@@ -53,8 +53,23 @@ export function Kanban() {
             setCards(cards.map(c => 
                 c.id === cardId ? { ...c, column: previousColumn } : c
             ))
-        } catch (error) {
+        } 
+        catch (error) {
             console.error('erro voltar card:', error)
+        }
+    }
+
+    const handleReturnToTodo = async (cardId: number) => {
+        const card = cards.find(c => c.id === cardId)
+        if (!card) return
+
+        try {
+            await updateCard(cardId, {column: 'todo'})
+            setCards(cards.map(c => 
+                c.id === cardId ? { ...c, column: 'todo' } : c
+            ))
+        } catch (error) {
+            console.error('erro retornar card para a fazer:', error)
         }
     }
 
@@ -93,8 +108,8 @@ export function Kanban() {
                 <KanbanColumn
                     title="Feito"
                     cards={cards.filter(card => card.column === 'done')}
-                    onMoveCard={handleMoveCard}
                     onMoveBack={handleBackCard}
+                    onReturn={handleReturnToTodo}
                     onDeleteCard={handleDeleteCard}
                 />
             </div>

--- a/frontend/src/pages/Kanban.tsx
+++ b/frontend/src/pages/Kanban.tsx
@@ -41,6 +41,23 @@ export function Kanban() {
         }
     } 
 
+    const handleBackCard = async (cardId: number) => {
+        const card = cards.find(c => c.id === cardId)
+        if (!card) return
+
+        const previousColumn = card.column === 'done' ? 'doing' : card.column === 'doing' ? 'todo' : undefined
+        if (!previousColumn) return
+
+        try {
+            await updateCard(cardId, {column: previousColumn})
+            setCards(cards.map(c => 
+                c.id === cardId ? { ...c, column: previousColumn } : c
+            ))
+        } catch (error) {
+            console.error('erro voltar card:', error)
+        }
+    }
+
     const handleDeleteCard = async (cardId: number) => {
         try {
             await deleteCard(cardId)
@@ -69,6 +86,7 @@ export function Kanban() {
                     title="Em andamento"
                     cards={cards.filter(card => card.column === 'doing')}
                     onMoveCard={handleMoveCard}
+                    onMoveBack={handleBackCard}
                     onDeleteCard={handleDeleteCard}
                 />
 
@@ -76,6 +94,7 @@ export function Kanban() {
                     title="Feito"
                     cards={cards.filter(card => card.column === 'done')}
                     onMoveCard={handleMoveCard}
+                    onMoveBack={handleBackCard}
                     onDeleteCard={handleDeleteCard}
                 />
             </div>


### PR DESCRIPTION
Adicionado risco no título dos cards quando chegam na coluna "Feito"

Botão de voltar (chevron_left): Transparente com borda, volta um passo na coluna
Botão de retorno (rotate_left): Azul, retorna direto para coluna "A fazer"
Ambos visíveis na coluna "Feito"

Colunas agora têm scroll interno em vez de esticar a página
Adicionadas classes min-h-0 e h-full para forçar preenchimento correto da altura
Cada coluna mantém tamanho fixo e rolável independentemente